### PR TITLE
Limit iminuit to 1.x version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 scipy
 iminuit>1.3,<1.4; python_version < '3.0'  # iminuit 1.4 fails on python 2.7.
-iminuit;          python_version >= '3.0'
+iminuit<2;        python_version >= '3.0' # iminuit changed API in v2.0.  We use the 1.x API.
 treecorr>=4.0
 fitsio>=0.9.12
 scikit-learn>=0.18

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ scripts = glob.glob("scripts/*.py")
 # Dependencies
 dependencies = ['numpy', 'scipy', 'treecorr>=4.0', 'fitsio>=0.9.12', 'scikit-learn>=0.18']
 if sys.version >= '3.0':
-    dependencies += ['iminuit']
+    dependencies += ['iminuit<2']
 else:
     # iminuit 1.4 fails on python 2.7
     dependencies += ['iminuit>=1.3,<1.4']


### PR DESCRIPTION
iminuit released a new version 2.0, which is backwards incompatible, and in particular breaks with treegp.

For now, this PR just limits the dependency to 1.x, but eventually probably worth updating the code to use the new API.