### PR TITLE
Fix warnings in python 3.8

### DIFF
--- a/tests/test_hyp_search.py
+++ b/tests/test_hyp_search.py
@@ -36,10 +36,10 @@ def test_hyperparameter_search_1d():
             # test if found hyperparameters are close the true hyperparameters.
             np.testing.assert_allclose(kernel_skl.theta, gp.kernel.theta, atol=7e-1)
             
-            if opt is "two-pcf":
+            if opt == "two-pcf":
                 xi, xi_weight, distance, coord, mask = gp.return_2pcf()
                 np.testing.assert_allclose(xi, gp._optimizer._2pcf, atol=1e-10)
-            if opt is "log-likelihood":
+            if opt == "log-likelihood":
                 logL = gp.return_log_likelihood()
                 np.testing.assert_allclose(logL, gp._optimizer._logL, atol=1e-10)
 

--- a/treegp/gp_interp.py
+++ b/treegp/gp_interp.py
@@ -99,7 +99,7 @@ class GPInterpolation(object):
         :param y:  Values of the field.  (n_samples)
         :param y_err: Error of y. (n_samples)
         """
-        if self.optimizer is not "none":
+        if self.optimizer != "none":
             # Hyperparameters estimation using 2-point correlation
             # function information.
             if self.optimizer in ['two-pcf', 'anisotropic']:

--- a/treegp/kernels.py
+++ b/treegp/kernels.py
@@ -43,7 +43,7 @@ def eval_kernel(kernel):
         raise RuntimeError("Failed to evaluate kernel string {0!r}.  "
                            "Original exception: {1}".format(kernel, e))
 
-    if type(k.theta) is property:
+    if isinstance(k.theta, property):
         raise TypeError("String provided was not initialized properly")
     return k
 


### PR DESCRIPTION
Python 3.8 now emits Warnings for `is` comparisons to literals.  This PR fixes these.