### PR TITLE
Update testing framework to pytest

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,0 +1,38 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Setup environment
+        run: |
+          sudo apt-get install -y libffi-dev
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest-codecov
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Install treegp
+        run: |
+          python setup.py install
+
+      - name: Test with pytest and submit to codecov
+        run: |
+          cd tests
+          pytest --codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
     - 3.6
     - 3.7
     - 3.8
+    - 3.9
 
 compiler:
     - g++
@@ -26,12 +27,12 @@ cache:
 
 install:
     - pip install -r requirements.txt
-    - pip install nose codecov
+    - pip install pytest-codecov
 
 script:
     - python setup.py install --prefix=$HOME
     - cd tests
-    - nosetests --with-coverage --cover-package=treegp
+    - pytest --codecov
 
 after_success:
     - codecov

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,7 +1,0 @@
-import os
-import glob
-
-tests = glob.glob("test_*")
-for test in tests:
-    os.system("python %s"%(test))
-


### PR DESCRIPTION
This pull request addresses #7.

Summary of changes:
- Removed `tests/run_tests.py` (not needed when using `pytest`).
- Switched testing program from nose to pytest (including changes in continuous integration dependencies).
- Added python 3.9 to the continuous integration testing environments.