### PR TITLE
Use GitHub Actions workflow for continuous integration

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install coverage pytest-codecov
+          pip install pytest-codecov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Install treegp
@@ -35,7 +35,4 @@ jobs:
       - name: Test with pytest and submit to codecov
         run: |
           cd tests
-          pytest --codecov --cov-report=
-      - name: Report coverage
-        run: |
-          coverage report
+          pytest --codecov

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest-codecov
+          pip install coverage pytest-codecov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Install treegp
@@ -36,3 +36,6 @@ jobs:
         run: |
           cd tests
           pytest --codecov
+      - name: Report coverage
+        run: |
+          coverage report

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -18,6 +18,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
+          sudo apt-get install -y libffi-dev
           python -m pip install --upgrade pip
           pip install codecov pytest-cov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -27,6 +27,7 @@ jobs:
           mkdir $HOME/lib/python${{ matrix.python-version }}/site-packages
 
       - name: Install dependencies
+        run: |
           python -m pip install --upgrade pip
           pip install codecov pytest-cov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Test with pytest and submit to codecov
         run: |
           cd tests
-          pytest --codecov
+          pytest --codecov --cov-report=
       - name: Report coverage
         run: |
           coverage report

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -12,16 +12,29 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+
+      - name: Setup environment
         run: |
           sudo apt-get install -y libffi-dev
+          export PYTHONPATH=$HOME/lib/python${{ matrix.python-version }}/site-packages/:$PYTHONPATH
+          mkdir $HOME/lib
+          mkdir $HOME/lib/python${{ matrix.python-version }}
+          mkdir $HOME/lib/python${{ matrix.python-version }}/site-packages
+
+      - name: Install dependencies
           python -m pip install --upgrade pip
           pip install codecov pytest-cov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Install treegp
+        run: |
+          - python setup.py install --prefix=$HOME
+
       - name: Test with pytest and submit to codecov
         run: |
           cd tests

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install treegp
         run: |
-          - python setup.py install --prefix=$HOME
+          - python setup.py install
 
       - name: Test with pytest and submit to codecov
         run: |

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest-cov codecov future
+          pip install pytest-cov codecov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Install treegp

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest-cov codecov
+          pip install pytest-codecov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Install treegp

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,0 +1,27 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install codecov pytest-cov
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Test with pytest and submit to codecov
+        run: |
+          cd tests
+          pytest --codecov

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -21,15 +21,11 @@ jobs:
       - name: Setup environment
         run: |
           sudo apt-get install -y libffi-dev
-          export PYTHONPATH=$HOME/lib/python${{ matrix.python-version }}/site-packages/:$PYTHONPATH
-          mkdir $HOME/lib
-          mkdir $HOME/lib/python${{ matrix.python-version }}
-          mkdir $HOME/lib/python${{ matrix.python-version }}/site-packages
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install codecov pytest-cov
+          pip install pytest-cov codecov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Install treegp

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest-cov codecov
+          pip install pytest-cov codecov future
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Install treegp

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install treegp
         run: |
-          - python setup.py install
+          python setup.py install
 
       - name: Test with pytest and submit to codecov
         run: |

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,3 @@
-.. image:: https://github.com/PFLeget/.github/workflows/actions/CI/badge.svg?branch=master&event=push)
 .. image:: https://travis-ci.org/PFLeget/treegp.svg?branch=master
     :target: https://travis-ci.org/PFLeget/treegp
 .. image:: https://codecov.io/gh/PFLeget/treegp/branch/master/graph/badge.svg

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,4 @@
+.. image:: https://github.com/PFLeget/.github/workflows/actions/CI/badge.svg?branch=master&event=push)
 .. image:: https://travis-ci.org/PFLeget/treegp.svg?branch=master
     :target: https://travis-ci.org/PFLeget/treegp
 .. image:: https://codecov.io/gh/PFLeget/treegp/branch/master/graph/badge.svg


### PR DESCRIPTION
These commits initialize a GitHub actions workflow for running continuous integration. GitHub Actions can be used alongside or instead of Travis, but generally seem to enable a faster development process (particularly through shorter queue times and ease of configuration).